### PR TITLE
 Add Test to Flag Missing Critical Dates for Wen Parker Reporting

### DIFF
--- a/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__invoice_line_items.yml
+++ b/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__invoice_line_items.yml
@@ -2,52 +2,54 @@ version: 2
 
 models:
   - name: stg_wen_parker__invoice_line_items
-    description: ""
+    description: |
+      Staging table for Wen Parker invoice line items. This table contains details about individual invoice lines, including 
+      information on the payer, charges, and invoice amounts. It is loaded daily with new invoice data from the source system
+      and is deduplicated because Wen Parker sends multiple records for the same invoice items.
     tags: ['daily']
     columns:
       - name: invoice_line_item_id
         data_type: string
-        description: ""
+        description: "Unique identifier for each invoice line item."
         tests:
           - unique
-          
+
       - name: invoice_number
         data_type: string
-        description: ""
+        description: "Invoice number associated with the line item."
 
       - name: invoice_date
         data_type: date
-        description: ""
+        description: "Date the invoice was issued."
 
       - name: payer_code
         data_type: string
-        description: ""
+        description: "Code identifying the payer responsible for the invoice."
 
       - name: payer_name
         data_type: string
-        description: ""
+        description: "Name of the payer responsible for the invoice."
 
       - name: shipment_type
         data_type: string
-        description: ""
+        description: "Type of shipment associated with the invoice (e.g., air, ocean, truck)."
 
       - name: house_bill_number
         data_type: string
-        description: ""
+        description: "House Bill of Lading (HBL) number associated with the shipment."
 
       - name: charge_code
         data_type: string
-        description: ""
+        description: "Code identifying the type of charge (e.g., freight, handling)."
 
       - name: charge_name
         data_type: string
-        description: ""
+        description: "Description of the charge (e.g., shipment cost, customs fee)."
 
       - name: invoice_currency
         data_type: string
-        description: ""
+        description: "Currency used for the invoice amount (e.g., USD, EUR)."
 
       - name: invoice_amount
         data_type: string
-        description: ""
-
+        description: "Amount billed in the invoice, represented as a string to handle currency formatting."

--- a/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__shipment_details.yml
+++ b/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__shipment_details.yml
@@ -2,92 +2,107 @@ version: 2
 
 models:
   - name: stg_wen_parker__shipment_details
-    description: ""
+    description: |
+      Staging table for Wen Parker shipment details. This table contains information about shipments, 
+      including tracking numbers, transportation details, weight, volume, and delivery dates.
+      This table is loaded daily with new shipment data from the source system and is deduplicated
+      because Wen Parker sends multiple records for the same shipment.
     tags: ['daily']
     columns:
       - name: shipment_id
         data_type: string
-        description: ""
+        description: "Unique identifier for each shipment."
         tests:
           - unique
-          
+
       - name: house_bill_number
         data_type: string
-        description: ""
+        description: "House Bill of Lading (HBL) number, used for tracking shipments at a more granular level."
 
       - name: master_bill_number
         data_type: string
-        description: ""
+        description: "Master Bill of Lading (MBL) number, assigned by the carrier to consolidate multiple shipments."
 
       - name: created_on
         data_type: date
-        description: ""
+        description: "Date the shipment record was created in the source system."
 
       - name: transportation_method
         data_type: string
-        description: ""
+        description: "Mode of transport used for the shipment (e.g., air, ocean, truck)."
 
       - name: co_load_bill_of_lading
         data_type: string
-        description: ""
+        description: "Indicates if the shipment is co-loaded with another Bill of Lading."
 
       - name: container_id
         data_type: string
-        description: ""
+        description: "Identifier for the container in which the shipment is stored."
 
       - name: vendor
         data_type: string
-        description: ""
+        description: "Name of the vendor handling the shipment."
 
       - name: origin_port_code
         data_type: string
-        description: ""
+        description: "Port code where the shipment originated."
 
       - name: destination_port_code
         data_type: string
-        description: ""
+        description: "Port code where the shipment is destined to arrive."
 
       - name: gross_weight
         data_type: float64
-        description: ""
+        description: "Total weight of the shipment, including packaging (measured in kilograms or pounds)."
 
       - name: chargeable_weight
         data_type: float64
-        description: ""
+        description: "Weight used for billing purposes, which may differ from actual weight due to dimensional weight calculations."
 
       - name: units
         data_type: int64
-        description: ""
+        description: "Number of units."
 
       - name: cubic_meters
         data_type: float64
-        description: ""
+        description: "Total volume in cubic meters."
 
       - name: cartons
         data_type: int64
-        description: ""
+        description: "Total number of cartons or boxes in the shipment."
 
       - name: cargo_received_on
         data_type: date
-        description: ""
+        description: "Date when the cargo was received by the carrier or warehouse."
+        tests:
+          - not_null:
+              severity: warn
 
       - name: actual_time_of_departure_origin_on
         data_type: date
-        description: ""
+        description: "Actual date when the shipment departed from the origin location."
 
       - name: actual_arrival_airport_wetport_on
         data_type: date
-        description: ""
+        description: "Date when the shipment actually arrived at the airport or wetport."
+        tests:
+          - not_null:
+              severity: warn
 
       - name: custom_release_on
         data_type: date
-        description: ""
+        description: "Date when the customs authority released the shipment for further processing."
+        tests:
+          - not_null:
+              severity: warn
 
       - name: delivery_address
         data_type: string
-        description: ""
+        description: "Final delivery address where the shipment is to be delivered."
 
       - name: delivered_on
         data_type: date
-        description: ""
-
+        description: "Date when the shipment was successfully delivered to the recipient."
+        tests:
+          - not_null:
+              severity: warn

--- a/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__shipment_item_details.yml
+++ b/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__shipment_item_details.yml
@@ -2,32 +2,33 @@ version: 2
 
 models:
   - name: stg_wen_parker__shipment_item_details
-    description: ""
+    description: |
+      Staging table for Wen Parker shipment item details. This table contains information about individual items in each shipment, 
+      including product details, quantities, and packaging information. It is loaded daily with new shipment item data from the source system.
     tags: ['daily']
     columns:
       - name: shipment_item_id
         data_type: string
-        description: ""
+        description: "Unique identifier for each shipment item."
         tests:
           - unique
 
       - name: house_bill_number
         data_type: string
-        description: ""
+        description: "House Bill of Lading (HBL) number associated with the shipment."
 
       - name: po_number
         data_type: string
-        description: ""
+        description: "Purchase order number associated with the shipment item."
 
       - name: cartons
         data_type: int64
-        description: ""
+        description: "Number of cartons or boxes containing the shipment item."
 
       - name: quantity
         data_type: int64
-        description: ""
+        description: "Quantity of the specific shipment item."
 
       - name: sku
         data_type: string
-        description: ""
-
+        description: "Stock Keeping Unit (SKU) identifier for the product being shipped."

--- a/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__tariff_details.yml
+++ b/quip_data/models/stage/wen_parker/schemas/stg_wen_parker__tariff_details.yml
@@ -2,32 +2,33 @@ version: 2
 
 models:
   - name: stg_wen_parker__tariff_details
-    description: ""
+    description: |
+      Staging table for Wen Parker tariff details. This table contains information about tariffs applied to shipments, 
+      including duties, fees, and costs. It is loaded daily with new tariff data from the source system.
     tags: ['daily']
     columns:
       - name: tariff_id
         data_type: string
-        description: ""
+        description: "Unique identifier for each tariff record."
         tests:
           - unique
 
       - name: house_bill_number
         data_type: string
-        description: ""
+        description: "House Bill of Lading (HBL) number associated with the shipment."
 
       - name: total_tariff_duty
         data_type: float64
-        description: ""
+        description: "Total duty applied to the shipment under the tariff."
 
       - name: tariff_number
         data_type: string
-        description: ""
+        description: "Tariff number identifying the specific tariff applied to the shipment."
 
       - name: total_fees
         data_type: float64
-        description: ""
+        description: "Total fees associated with the tariff, including any additional charges."
 
       - name: total_tariff_cost
         data_type: float64
-        description: ""
-
+        description: "Total cost of the tariff, including duties and fees."

--- a/quip_data/models/stage/wen_parker/stg_wen_parker__invoice_line_items.sql
+++ b/quip_data/models/stage/wen_parker/stg_wen_parker__invoice_line_items.sql
@@ -1,3 +1,17 @@
+{{ config(
+    partition_by={
+      "field": "invoice_date",
+      "data_type": "timestamp",
+      "granularity": "day"
+    },
+	cluster_by=[
+        "house_bill_number",
+        "shipment_type", 
+		"invoice_number",
+        "invoice_line_item_id"
+    ]
+) }}
+
 WITH source AS (
     SELECT * FROM {{ source('wen_parker', 'invoice_line_items') }}
 )

--- a/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_details.sql
+++ b/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_details.sql
@@ -1,6 +1,6 @@
 {{ config(
     partition_by={
-      "field": "source_synced_at",
+      "field": "cargo_received_on",
       "data_type": "timestamp",
       "granularity": "day"
     },

--- a/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_details.sql
+++ b/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_details.sql
@@ -22,7 +22,6 @@ WITH source AS (
         'house_bill_number'
         , 'master_bill_number'
         , 'transportation_method'
-        , 'container_id'
         , 'vendor'
         , 'origin_port_code'
         , 'destination_port_code'

--- a/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_item_details.sql
+++ b/quip_data/models/stage/wen_parker/stg_wen_parker__shipment_item_details.sql
@@ -1,3 +1,17 @@
+{{ config(
+    partition_by={
+      "field": "source_synced_at",
+      "data_type": "timestamp",
+      "granularity": "day"
+    },
+	cluster_by=[
+        "sku",
+        "po_number", 
+		"house_bill_number",
+        "shipment_item_id"
+    ]
+) }}
+
 WITH source AS (
     SELECT * FROM {{ source('wen_parker', 'shipment_item_details') }}
 )

--- a/quip_data/models/stage/wen_parker/stg_wen_parker__tariff_details.sql
+++ b/quip_data/models/stage/wen_parker/stg_wen_parker__tariff_details.sql
@@ -1,3 +1,15 @@
+{{ config(
+    partition_by={
+      "field": "source_synced_at",
+      "data_type": "timestamp",
+      "granularity": "day"
+    },
+	cluster_by=[
+		"house_bill_number",
+        "tariff_number"
+    ]
+) }}
+
 WITH source AS (
     SELECT * FROM {{ source('wen_parker', 'tariff_details') }}
 )


### PR DESCRIPTION
#### **Background:**
Stakeholders recently noticed that we were missing critical dates (e.g., `cargo_received_on`, `delivered_on`, etc.) in our reporting. After investigating, we identified that the root cause of this issue is related to incomplete or missing data from the source system.

#### **Purpose:**
To prevent this issue from going unnoticed in the future, we’ve added a test to flag any missing critical dates in the `stg_wen_parker__shipment_details` model. This will allow us to monitor and alert on these missing values, improving our data quality and reporting accuracy.

#### **Test Details:**
- We’ve implemented `not_null` tests for the relevant date fields in the model.
- The test has been set to **warn** rather than fail because we are aware that some records currently have missing dates. This will allow the team to be notified without blocking the dbt run.
- We are actively working with the data source team to address this issue at the source. Once the source fixes the problem and ensures consistent data, we will update the test to **fail** if any critical dates are missing.

#### **Next Steps:**
- Continue monitoring the warnings generated by this test.
- Request the source team to fix the data issue to ensure that these critical dates are populated correctly in future records.
- Once the issue is resolved at the source, we will update the test to fail when data is missing.

#### **Impact:**
This change does not block any dbt runs but ensures that missing data is flagged for future action. We will be able to identify and address these issues proactively before they impact reporting.

#### Other New Configurations:
Partitioning: We've added partitioning fields with a daily granularity to optimize query performance for large datasets.
Clustering: We’ve also implemented clustering to enhance query performance when filtering by these fields.