### PR TITLE
Create Intermediate Table for Credit Events in Payments

### DIFF
--- a/quip_data/dbt_project.yml
+++ b/quip_data/dbt_project.yml
@@ -59,6 +59,8 @@ models:
         +schema: order_items
       orders:
         +schema: orders
+      payments:
+        +schema: payments
       products:
         +schema: products
       subscriptions:

--- a/quip_data/models/_docs.md
+++ b/quip_data/models/_docs.md
@@ -1,0 +1,3 @@
+{% docs amount %}
+    The monetary value associated with the record.  
+{% enddocs %}

--- a/quip_data/models/intermediate/payments/int_payments__credit_events.sql
+++ b/quip_data/models/intermediate/payments/int_payments__credit_events.sql
@@ -1,0 +1,95 @@
+{{ config(
+    partition_by={
+      "field": "created_at",
+      "data_type": "timestamp",
+      "granularity": "day"
+    },
+	cluster_by=[
+		"payment_transaction_type",
+        "recharge_customer_id",
+		"shopify_order_id",
+		"credit_event_id"
+    ]
+) }}
+
+WITH
+
+credit_accounts AS (
+	SELECT * FROM {{ ref("stg_recharge__credit_accounts") }}
+)
+
+, credit_adjustments AS (
+	SELECT * FROM {{ ref("stg_recharge__credit_adjustments") }}
+)
+
+, charges AS (
+	SELECT * FROM {{ ref("stg_recharge__charges") }}
+)
+
+-------------------------------------------------------
+----------------- FINISH REFERENCES -------------------
+-------------------------------------------------------
+
+, transactions AS (
+	-- parse credit transactions from charges
+	SELECT
+		recharge_charge_id
+		, recharge_customer_id
+		, shopify_order_id
+		, transactions.external_transaction_id AS credit_adjustment_id
+		, SAFE_CAST(transactions.amount AS FLOAT64) AS amount
+		, transactions.created_at AS created_at
+		, IF(transactions.kind != 'refund', 'debit', 'credit') AS payment_transaction_type
+		, IF(transactions.kind = 'refund', 'refund', 'unapplicable') AS credit_type
+	FROM charges
+	INNER JOIN UNNEST(transactions) AS transactions
+		ON transactions.processor_name = 'recharge_credits'
+	WHERE charges.status IN ('partially_refunded', 'success', 'refunded')
+
+)
+
+, unioned AS (
+	-- get credit issued event
+	SELECT
+		credit_account_id
+		, recharge_customer_id
+		, NULL AS recharge_charge_id
+		, 'credit' AS payment_transaction_type
+		, NULL AS shopify_order_id
+		, initial_amount AS amount
+		, created_at
+		, credit_type
+	FROM credit_accounts
+
+	UNION ALL
+
+	-- join transactions to adjustments for account level info
+	SELECT
+		adjustments.credit_account_id
+		, transactions.recharge_customer_id
+		, transactions.recharge_charge_id
+		, COALESCE(transactions.payment_transaction_type, adjustments.adjustment_type) AS payment_transaction_type
+		, transactions.shopify_order_id
+		, transactions.amount
+		, COALESCE(transactions.created_at, adjustments.created_at) AS created_at
+		, transactions.credit_type
+	FROM transactions
+	LEFT JOIN credit_adjustments AS adjustments
+		ON adjustments.credit_adjustment_id = adjustments.credit_adjustment_id
+)
+
+SELECT
+	*
+	, {{ dbt_utils.generate_surrogate_key(
+		[
+			'credit_account_id'
+			, 'recharge_customer_id'
+			, 'recharge_charge_id'
+			, 'payment_transaction_type'
+			, 'credit_type'
+			, 'created_at'
+		]
+	) }} AS credit_event_id
+FROM unioned
+
+

--- a/quip_data/models/intermediate/payments/schemas/_docs.md
+++ b/quip_data/models/intermediate/payments/schemas/_docs.md
@@ -1,0 +1,14 @@
+{% docs payment_transaction_type %}
+	The category of transaction that occurs within a payment system. 
+	- credit represents currency issued to a customer
+	- debit represents currency used by a customer
+{% enddocs %}
+
+{% docs credit_type %}
+    The classification of the credit event.  
+    Possible values may include:
+    - `manual` – Credit manually added by an admin.  
+    - `refund` – Credit issued as a refund for a previous transaction.  
+    - `reward` – Credit given as part of our loyalty program.  
+    - `gift` – Credit added from a giftcard.  
+{% enddocs %}

--- a/quip_data/models/intermediate/payments/schemas/int_payments__credit_events.yml
+++ b/quip_data/models/intermediate/payments/schemas/int_payments__credit_events.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: int_payments__credit_events
+    description: |
+      This model captures credit-related events for payments, linking customer transactions with Recharge and Shopify order data.
+    columns:
+      - name: credit_account_id
+        data_type: int64
+        description: '{{ doc("credit_account_id")}}'
+
+      - name: recharge_customer_id
+        data_type: int64
+        description: '{{ doc("recharge_customer_id")}}'
+
+      - name: recharge_charge_id
+        data_type: int64
+        description: '{{ doc("recharge_charge_id")}}'
+
+      - name: payment_transaction_type
+        data_type: string
+        description: '{{ doc("payment_transaction_type")}}'
+
+      - name: shopify_order_id
+        data_type: string
+        description: '{{ doc("shopify_order_id")}}'
+
+      - name: amount
+        data_type: float64
+        description: '{{ doc("amount")}}'
+
+      - name: created_at
+        data_type: timestamp
+        description: ""
+
+      - name: credit_type
+        data_type: string
+        description: '{{ doc("credit_type")}}'
+
+      - name: credit_event_id
+        data_type: string
+        description: " A unique identifier for the credit event transaction."
+

--- a/quip_data/models/stage/recharge/schemas/_docs.md
+++ b/quip_data/models/stage/recharge/schemas/_docs.md
@@ -1,0 +1,13 @@
+{% docs recharge_customer_id %}
+    A unique identifier for the customer in Recharge.
+{% enddocs %}
+
+{% docs recharge_charge_id %}
+    A unique identifier for a charge transaction in Recharge. 
+{% enddocs %}
+
+{% docs credit_account_id %}
+    A unique identifier for the credit account associated with a customer.  
+    This ID links credit transactions to a specific customer account within the payment system.
+	A customer can have many credit accounts, and credit accounts are created when customers are issued new credits.
+{% enddocs %}

--- a/quip_data/models/stage/recharge/schemas/stg_recharge__charges.yml
+++ b/quip_data/models/stage/recharge/schemas/stg_recharge__charges.yml
@@ -2,11 +2,19 @@ version: 2
 
 models:
   - name: stg_recharge__charges
-    description: ""
+    description: |
+      A charge is the representation of a financial transaction linked to the purchase of an item (past or future). 
+      It can be a transaction that was processed already or the representation of an upcoming transaction.
+
+      Read more: https://developer.rechargepayments.com/2021-11/charges
     columns:
-      - name: charge_id
+      - name: recharge_charge_id
         data_type: int64
-        description: ""
+        description: '{{ doc("recharge_charge_id" )}}'
+        
+      - name: shopify_order_id
+        data_type: string
+        description: '{{ doc("shopify_order_id")}}'
 
       - name: address_id
         data_type: int64

--- a/quip_data/models/stage/recharge/schemas/stg_recharge__credit_accounts.yml
+++ b/quip_data/models/stage/recharge/schemas/stg_recharge__credit_accounts.yml
@@ -2,7 +2,12 @@ version: 2
 
 models:
   - name: stg_recharge__credit_accounts
-    description: ""
+    description: |
+      A credit account is a representation of a credit balance that can be used to pay for future charges.
+      A customer can have many credit accounts, and credit accounts are created when customers are issued new credits.
+      Credit accounts may not have negative balances.
+
+      Read more: https://developer.rechargepayments.com/2021-11/credits
     columns:
       - name: credit_account_id
         data_type: int64

--- a/quip_data/models/stage/recharge/stg_recharge__credit_accounts.sql
+++ b/quip_data/models/stage/recharge/stg_recharge__credit_accounts.sql
@@ -1,16 +1,28 @@
+{{ config(
+    partition_by={
+      "field": "updated_at",
+      "data_type": "timestamp",
+      "granularity": "day"
+    },
+	cluster_by=[
+		"credit_account_id",
+        "recharge_customer_id"
+    ]
+) }}
+
 WITH source AS (
     SELECT * FROM {{ source('recharge', 'credit_accounts') }}
 )
 
 SELECT
     id AS credit_account_id
-    , customer_id
+    , customer_id AS recharge_customer_id
     , available_balance
     , created_at
     , currency_code
     , expires_at
-    , initial_value
-    , type AS credit_applied_by
+    , SAFE_CAST(initial_value AS FLOAT64) AS initial_amount
+    , type AS credit_type
     , updated_at
     , source_synced_at
     , LOWER(name) AS credit_name

--- a/quip_data/models/stage/recharge/stg_recharge__credit_accounts.sql
+++ b/quip_data/models/stage/recharge/stg_recharge__credit_accounts.sql
@@ -29,6 +29,6 @@ SELECT
 FROM source
 -- dedupe
 QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY id
+        PARTITION BY credit_account_id
         ORDER BY updated_at DESC
     ) = 1

--- a/quip_data/models/stage/recharge/stg_recharge__credit_adjustments.sql
+++ b/quip_data/models/stage/recharge/stg_recharge__credit_adjustments.sql
@@ -18,6 +18,6 @@ SELECT
 FROM source
 -- dedupe
 QUALIFY ROW_NUMBER() OVER (
-        PARTITION BY id
+        PARTITION BY credit_adjustment_id
         ORDER BY updated_at DESC
     ) = 1

--- a/quip_data/models/stage/shopify/schemas/docs.md
+++ b/quip_data/models/stage/shopify/schemas/docs.md
@@ -1,3 +1,3 @@
-{% docs subtotal_price %}
-
+{% docs shopify_order_id %}
+    A unique identifier for the related order in Shopify.  
 {% enddocs %}


### PR DESCRIPTION
## **Description:**  
This PR introduces the creation of an intermediate table, `int_payments__credit_events`, designed to track and store credit-related events for payments. The table will serve as a bridge between various systems (Recharge, Shopify, etc.) and provide a consolidated view of all credit transactions related to customer payments.

## **Changes Made:**
- Created the `int_payments__credit_events` table to capture credit events for customer transactions.
- Added the following columns to the table:
  - `credit_account_id`: A unique identifier for the credit account linked to the transaction.
  - `recharge_customer_id`: A unique identifier for the customer in Recharge.
  - `recharge_charge_id`: The unique identifier for a charge transaction in Recharge.
  - `transaction_type`: The type of transaction (e.g., credit issued, credit redeemed).
  - `shopify_order_id`: The related Shopify order ID, if applicable.
  - `amount`: The monetary value of the credit transaction.
  - `created_at`: The timestamp when the credit event was created.
  - `credit_type`: The classification of the credit event (e.g., manual, refund, promotional).
  - `credit_event_id`: A unique identifier for the credit event itself.
  
## **Why This is Needed:**
- This intermediate table consolidates critical information about credit transactions, enabling downstream analysis and reporting.
- The table provides a unified structure for tracking customer credit activities, ensuring compatibility across different platforms (Recharge and Shopify).
- It improves data accessibility for future reporting, analytics, and decision-making processes.

## **Tests**
### uniqueness
![Screenshot 2025-02-20 at 8 33 36 PM](https://github.com/user-attachments/assets/631b8163-44fd-4d37-9afd-6ab51884000d)
