### PR TITLE
operations__logistics_sku_fees fix

### DIFF
--- a/quip_data/models/mart/operations/operations__logistics_sku_fees.sql
+++ b/quip_data/models/mart/operations/operations__logistics_sku_fees.sql
@@ -20,9 +20,11 @@ SELECT
 	, 'tariff' AS fee_type
 	, tariff_type AS fee_detail_1
 	, tariff_number AS fee_detail_2
-	, total_allocated_tariff_cost AS total_allocated_amount
+	, {{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'tariff_type', 'tariff_number']) }} as row_id
+	, SUM(total_allocated_tariff_cost) AS total_allocated_amount
 FROM tariffs
 WHERE tariff_type = 'hts_china'
+GROUP BY 1,2,3,4,5,6,7
 
 UNION ALL
 
@@ -33,9 +35,11 @@ SELECT
 	, 'tariff' AS fee_type
 	, tariff_type AS fee_detail_1
 	, tariff_number AS fee_detail_2
-	, total_allocated_tariff_cost AS total_allocated_amount
+	, {{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'tariff_type', 'tariff_number']) }} as row_id
+	, SUM(total_allocated_tariff_cost) AS total_allocated_amount
 FROM tariffs
 WHERE tariff_type = 'hts'
+GROUP BY 1,2,3,4,5,6,7
 
 UNION ALL
 
@@ -46,6 +50,7 @@ SELECT
 	, charge_category AS fee_type
 	, charge_code AS fee_detail_1
 	, charge_name AS fee_detail_2
-	, allocated_invoice_amount AS total_allocated_amount
+	, {{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'charge_category', 'charge_code', 'charge_name']) }} as row_id
+	, SUM(allocated_invoice_amount) AS total_allocated_amount
 FROM fees
-
+GROUP BY 1,2,3,4,5,6,7


### PR DESCRIPTION
Update operations__logistics_sku_fees.sql

This model should be the equivalent of this one from 1.0: https://quip-data-production.uc.r.appspot.com/#!/model/model.quip_transformations.wen_parker__allocated_fees

But it wasn't. The total_allocated_amount needed to be rolled up.

I connected my dev table to Looker, and validated for one HBL. The numbers are now correct:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/19969b39-4f62-4d8d-920b-f7f432a74023" />
