### PR TITLE
Update operations__logistics_sku_fees.sql

### DIFF
--- a/quip_data/models/mart/operations/operations__logistics_sku_fees.sql
+++ b/quip_data/models/mart/operations/operations__logistics_sku_fees.sql
@@ -17,14 +17,13 @@ SELECT
 	{{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'tariff_type', 'tariff_number']) }} as id
 	, house_bill_number
 	, sku
-	, sku_presentment
 	, 'tariff' AS fee_type
 	, tariff_type AS fee_detail_1
 	, tariff_number AS fee_detail_2
 	, SUM(total_allocated_tariff_cost) AS total_allocated_amount
 FROM tariffs
 WHERE tariff_type = 'hts_china'
-GROUP BY 1,2,3,4,5,6,7
+GROUP BY 1,2,3,4,5,6
 
 UNION ALL
 
@@ -32,14 +31,13 @@ SELECT
 	{{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'tariff_type', 'tariff_number']) }} as id
 	, house_bill_number
 	, sku
-	, sku_presentment
 	, 'tariff' AS fee_type
 	, tariff_type AS fee_detail_1
 	, tariff_number AS fee_detail_2
 	, SUM(total_allocated_tariff_cost) AS total_allocated_amount
 FROM tariffs
 WHERE tariff_type = 'hts'
-GROUP BY 1,2,3,4,5,6,7
+GROUP BY 1,2,3,4,5,6
 
 UNION ALL
 
@@ -47,10 +45,9 @@ SELECT
 	{{ dbt_utils.generate_surrogate_key(['house_bill_number', 'sku', 'charge_category', 'charge_code', 'charge_name']) }} as id	
 	, house_bill_number
 	, sku
-	, sku_presentment
 	, charge_category AS fee_type
 	, charge_code AS fee_detail_1
 	, charge_name AS fee_detail_2
 	, SUM(allocated_invoice_amount) AS total_allocated_amount
 FROM fees
-GROUP BY 1,2,3,4,5,6,7
+GROUP BY 1,2,3,4,5,6


### PR DESCRIPTION
Removed `sku_presentment` because it is unneeded. Since the primary key was based on the `sku`, and not `sku_presentment`, records were getting assigned the same primary key if a single `sku` had multiple `sku_presentment`. This is no longer an issue. QA below --

<img width="615" alt="image" src="https://github.com/user-attachments/assets/5a0d5dcc-e164-4e7d-8b67-592aa451f1aa" />

I also temporarily switched the Looker view to my dev table (`quip-dw-mart-dev.dipali_operations.operations__logistics_sku_fees`) to validate that things are working correctly, I can see the numbers are appearing correctly in the Explore (previously was throwing an error message) - 

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/98c86027-bcde-41db-8951-94e60633eab0" />
